### PR TITLE
fix compilation on macos and general code fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,14 @@ CC = g++
 
 # Any special flags you want to pass to the compiler
 MYFLAGS = -Wall -Wno-sign-compare -Wunused -Wno-unused-local-typedefs -Wno-format-truncation -Wformat -O0 -ggdb3 -fno-inline -std=c++11
-LIBS = -lz -lpthread -lnsl -lm -lc -lcrypt
+
+LIBS =
+ifeq ($(UNAME_S),Darwin)
+	LIBS = -lz -lpthread -lm -lc -lcrypt
+else
+	LIBS = -lz -lpthread -lnsl -lm -lc -lcrypt
+endif
+
 SRCFILES := $(wildcard *.cpp)
 OBJFILES := $(patsubst %.cpp,%.o,$(SRCFILES))
 ifeq ($(ECL),1)

--- a/act.offensive.cpp
+++ b/act.offensive.cpp
@@ -580,7 +580,7 @@ ACMD ( do_shoot )
 
     }
 
-    if ( !holding || holding < 0 )
+    if ( !holding || holding == NULL )
     {
         ch->Send ( "Snap it's broken! It probably has the wrong kinda ammo in it.\r\n" );
         return;
@@ -809,4 +809,3 @@ ACMD ( do_ignore )
      gain += (GET_MANA(ch) / 2);
    }
 */
-

--- a/act.wizard.cpp
+++ b/act.wizard.cpp
@@ -1234,10 +1234,8 @@ ACMD ( do_atlvl )
 
 ACMD ( do_goto )
 {
-    room_rnum location;
-    char buf[MAX_INPUT_LENGTH];
-
-    if ( ( location = find_target_room ( ch, argument ) ) < 0 )
+    Room* location = find_target_room(ch, argument);
+    if (location == NULL)
         return;
 
     if ( location == IN_ROOM ( ch ) )
@@ -1246,6 +1244,7 @@ ACMD ( do_goto )
         return;
     }
 
+    char buf[MAX_INPUT_LENGTH];
     if ( POOFOUT ( ch ) )
         snprintf ( buf, sizeof ( buf ), "%s", POOFOUT ( ch ) );
     else
@@ -1368,7 +1367,7 @@ ACMD ( do_teleport )
         send_to_char ( "Maybe you shouldn't do that.\r\n", ch );
     else if ( !*buf2 )
         send_to_char ( "Where do you wish to send this person?\r\n", ch );
-    else if ( ( target = find_target_room ( ch, buf2 ) ) >= 0 )
+    else if ((target = find_target_room(ch, buf2)) != NULL)
     {
         ch->Send ( "%s", CONFIG_OK );
         act ( "$n disappears in a puff of smoke.", FALSE, victim, 0, 0,  TO_ROOM );

--- a/arena.cpp
+++ b/arena.cpp
@@ -225,7 +225,7 @@ ACMD ( do_chaos )
         ch->Send ( "Please choose a hi_lim under the Imps level\r\n" );
         return;
     }
-    if ( lolimit < 0 )
+    if (*lolimit < 0)
         silent_end();
     if ( !*lolimit || !*hilimit || !*start_delay || !*cost || !*length )
     {

--- a/comm.cpp
+++ b/comm.cpp
@@ -4636,4 +4636,3 @@ void mccp_off(Descriptor *d) {
 #include "dlib/dir_nav/dir_nav_kernel_1.cpp"
 #include "dlib/dir_nav/dir_nav_kernel_2.cpp"
 //#include "dlib/linker/linker_kernel_1.cpp"
-

--- a/db.cpp
+++ b/db.cpp
@@ -1322,7 +1322,7 @@ void load_explored ( const Character *ch )
         return;
 
     int i = 0;
-    ulong x;
+    unsigned long x;
     while ( i < SPECIALS ( ch )->explored.size() )
     {
         f >> x;

--- a/descriptor.h
+++ b/descriptor.h
@@ -95,11 +95,9 @@ public:
     int process_input();
     template<typename T>
     Descriptor & operator<< (const T & i) {
-        if (this) {
-            stringstream s;
-            s << i;
-            Output((string&)s.str());
-        }
+        stringstream s;
+        s << i;
+        Output(s);
         return *this;
     };
     protocol_t *pProtocol; /* @TODO:PROTOCOL */

--- a/protocol.cpp
+++ b/protocol.cpp
@@ -15,7 +15,13 @@
 #include <string.h>
 #include <arpa/telnet.h>
 #include <time.h>
+
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
+
 #include <ctype.h>
 
 #include <string>

--- a/sysdep.h
+++ b/sysdep.h
@@ -250,8 +250,12 @@ extern void abort (), exit ();
 #include <sys/errno.h>
 #endif
 
+#if defined(__APPLE__)
+#include <unistd.h>
+#else
 #ifdef HAVE_CRYPT_H
 #include <crypt.h>
+#endif
 #endif
 
 #ifdef TIME_WITH_SYS_TIME
@@ -350,7 +354,13 @@ extern void abort (), exit ();
 
 
 /* Basic system dependencies *******************************************/
+
+
+#if defined (__APPLE__)
+#include <mach/error.h>
+#else
 #include <mcheck.h>
+#endif
 
 #if CIRCLE_GNU_LIBC_MEMORY_TRACK && !defined(HAVE_MCHECK_H)
 #error "Cannot use GNU C library memory tracking without <mcheck.h>"
@@ -426,11 +436,11 @@ extern void abort (), exit ();
 #ifdef CIRCLE_WINDOWS
 # define CLOSE_SOCKET(sock)	closesocket(sock)
 
-typedef SOCKET		socket_t;
+    typedef SOCKET socket_t;
 #else
 # define CLOSE_SOCKET(sock)	close(sock)
 
-typedef int			socket_t;
+    typedef int socket_t;
 #endif
 
 #if defined(__cplusplus)	/* C++ */


### PR DESCRIPTION
compiling with LLVM is catching many errors ignored by G++ compiler: like comparing pointers to integers and the sort.

we should resolve these issues for a stable codebase.

fixes #44 
